### PR TITLE
Follow Pagination, Delays & Page Size Param

### DIFF
--- a/Teams/Set-NotificationsAsRead.ps1
+++ b/Teams/Set-NotificationsAsRead.ps1
@@ -1,84 +1,115 @@
-# Clear all Microsoft Teams notifications
+# Clear All Microsoft Teams Notifications
 
 Import-Module AADInternals
 
-#This will prompt for credentials so it supports MFA login
-$token = Get-AADIntAccessTokenForTeams
+# This will prompt for credentials so it supports MFA login
 
-$skypeToken = Get-AADIntSkypeToken -AccessToken $token
+if($null -eq $global:Token) {
 
-$result=Invoke-WebRequest -UseBasicParsing -Uri "https://amer.ng.msg.teams.microsoft.com/v1/users/ME/conversations/48%3Anotifications/messages?view=msnp24Equivalent|supportsMessageProperties&pageSize=200" `
--Headers @{
-"method"="GET"
-  "authority"="amer.ng.msg.teams.microsoft.com"
-  "scheme"="https"
-  "path"="/v1/users/ME/conversations/48%3Anotifications/messages?view=msnp24Equivalent|supportsMessageProperties&pageSize=200"
-  "sec-ch-ua"="`" Not A;Brand`";v=`"99`", `"Chromium`";v=`"96`", `"Microsoft Edge`";v=`"96`""
-  "x-ms-session-id"="ae16f178-a088-a7bb-603b-27aad38b6c88"
-  "behavioroverride"="redirectAs404"
-  "x-ms-scenario-id"="130"
-  "x-ms-client-cpm"="ApplicationLaunch"
-  "x-ms-client-env"="pds-prod-azsc-usce-01"
-  "x-ms-client-type"="web"
-  "sec-ch-ua-mobile"="?0"
-  "clientinfo"="os=windows; osVer=10; proc=x86; lcid=en-us; deviceType=1; country=us; clientName=skypeteams; clientVer=1415/1.0.0.2021120940; utcOffset=-06:00; timezone=America/Costa_Rica"
-  "x-ms-client-version"="1415/1.0.0.2021120940"
-  "x-ms-user-type"="null"
-  "authentication"="skypetoken=$skypeToken"
-  "sec-ch-ua-platform"="`"Windows`""
-  "origin"="https://teams.microsoft.com"
-  "sec-fetch-site"="same-site"
-  "sec-fetch-mode"="cors"
-  "sec-fetch-dest"="empty"
-  "referer"="https://teams.microsoft.com/"
-  "accept-encoding"="gzip, deflate, br"
-  "accept-language"="es,es-ES;q=0.9,en;q=0.8,en-GB;q=0.7,en-US;q=0.6"
+	Write-Host 'Getting Token...'
+
+	$global:Token 	= Get-AADIntAccessTokenForTeams
+	$global:Token 	= Get-AADIntSkypeToken -AccessToken $global:Token
+
+}
+else {
+	Write-Host 'We Already Have A Token, Proceeding...'
 }
 
-$messages=ConvertFrom-Json -InputObject $result.Content
+$Root	= 'https://amer.ng.msg.teams.microsoft.com';
+$Path	= '/v1/users/ME/conversations/48%3Anotifications/messages/';
+$Query	= '?view=msnp24Equivalent|supportsMessageProperties&pageSize='+$args[0];
+$URI 	= $Path+$Query;
+$URL 	= $Root+$URI;
 
+while($URL) {
 
-$NotificationsToClear=$messages.messages | where-object {$_.properties.isread -ne "True"}
+	$Result	= Invoke-WebRequest -UseBasicParsing -Uri "$URL" `
+	-Headers @{
+	"method"="GET"
+	"authority"="amer.ng.msg.teams.microsoft.com"
+	"scheme"="https"
+	"path"="$URI"
+	"sec-ch-ua"="`" Not A;Brand`";v=`"99`", `"Chromium`";v=`"96`", `"Microsoft Edge`";v=`"96`""
+	"x-ms-session-id"="ae16f178-a088-a7bb-603b-27aad38b6c88"
+	"behavioroverride"="redirectAs404"
+	"x-ms-scenario-id"="130"
+	"x-ms-client-cpm"="ApplicationLaunch"
+	"x-ms-client-env"="pds-prod-azsc-usce-01"
+	"x-ms-client-type"="web"
+	"sec-ch-ua-mobile"="?0"
+	"clientinfo"="os=windows; osVer=10; proc=x86; lcid=en-us; deviceType=1; country=us; clientName=skypeteams; clientVer=1415/1.0.0.2021120940; utcOffset=-06:00; timezone=America/Costa_Rica"
+	"x-ms-client-version"="1415/1.0.0.2021120940"
+	"x-ms-user-type"="null"
+	"authentication"="skypetoken=$global:Token"
+	"sec-ch-ua-platform"="`"Windows`""
+	"origin"="https://teams.microsoft.com"
+	"sec-fetch-site"="same-site"
+	"sec-fetch-mode"="cors"
+	"sec-fetch-dest"="empty"
+	"referer"="https://teams.microsoft.com/"
+	"accept-encoding"="gzip, deflate, br"
+	"accept-language"="es,es-ES;q=0.9,en;q=0.8,en-GB;q=0.7,en-US;q=0.6"
+	}
 
+	$Data					= ConvertFrom-Json -InputObject $result.Content
+	$URL 					= $Data._metadata.backwardLink
+	$NotificationsToClear	= $Data.messages | where-object {$_.properties.isread -ne "True"}
+	
+	foreach($N in $NotificationsToClear) {
+		
+		$_PathEnd_Query	= "/properties?name=isread"
+		$PUT			= $Root+$Path+$N.Id+$_PathEnd_Query
 
-foreach($notifications in $notificationsToClear)
-{
+		Write-Host "Clearing Notification: "$N.Id
 
-$urlFQDN="https://amer.ng.msg.teams.microsoft.com"
-$urlPart1="/v1/users/ME/conversations/48%3Anotifications/messages/"
-$urlPart3="/properties?name=isread"
-$finalUrl=$urlFQDN+$urlPart1+$notifications.Id+$urlPart3
+		try {
 
-Write-Host "Clearing notification" $notifications.Id
+			$Result = Invoke-WebRequest -UseBasicParsing -Uri $PUT `
+			-Method "PUT" `
+			-Headers @{
+			"method"="PUT"
+			"authority"="amer.ng.msg.teams.microsoft.com"
+			"scheme"="https"
+			"path"=$Path+$N.Id+$_PathEnd_Query
+			"sec-ch-ua"="`" Not A;Brand`";v=`"99`", `"Chromium`";v=`"96`", `"Microsoft Edge`";v=`"96`""
+			"x-ms-user-type"="null"
+			"x-ms-client-type"="web"
+			"x-ms-client-version"="1415/1.0.0.2021120940"
+			"authentication"="skypetoken=$Token"
+			"sec-ch-ua-platform"="`"Windows`""
+			"x-ms-scenario-id"="716"
+			"x-ms-client-env"="pckgsvc-prod-c1-usea-01"
+			"sec-ch-ua-mobile"="?0"
+			"clientinfo"="os=windows; osVer=10; proc=x86; lcid=en-us; deviceType=1; country=us; clientName=skypeteams; clientVer=1415/1.0.0.2021120940; utcOffset=-06:00; timezone=America/Costa_Rica"
+			"behavioroverride"="redirectAs404"
+			"x-ms-client-caller"="markReadStatus"
+			"origin"="https://teams.microsoft.com"
+			"sec-fetch-site"="same-site"
+			"sec-fetch-mode"="cors"
+			"sec-fetch-dest"="empty"
+			"referer"="https://teams.microsoft.com/"
+			"accept-encoding"="gzip, deflate, br"
+			"accept-language"="es,es-ES;q=0.9,en;q=0.8,en-GB;q=0.7,en-US;q=0.6"
+			} `
+			-ContentType "application/json" `
+			-Body "{`"isread`":true}"
 
-$result=Invoke-WebRequest -UseBasicParsing -Uri $finalUrl `
--Method "PUT" `
--Headers @{
-"method"="PUT"
-  "authority"="amer.ng.msg.teams.microsoft.com"
-  "scheme"="https"
-  "path"=$urlPart1+$notifications.Id+$urlPart3
-  "sec-ch-ua"="`" Not A;Brand`";v=`"99`", `"Chromium`";v=`"96`", `"Microsoft Edge`";v=`"96`""
-  "x-ms-user-type"="null"
-  "x-ms-client-type"="web"
-  "x-ms-client-version"="1415/1.0.0.2021120940"
-  "authentication"="skypetoken=$skypeToken"
-  "sec-ch-ua-platform"="`"Windows`""
-  "x-ms-scenario-id"="716"
-  "x-ms-client-env"="pckgsvc-prod-c1-usea-01"
-  "sec-ch-ua-mobile"="?0"
-  "clientinfo"="os=windows; osVer=10; proc=x86; lcid=en-us; deviceType=1; country=us; clientName=skypeteams; clientVer=1415/1.0.0.2021120940; utcOffset=-06:00; timezone=America/Costa_Rica"
-  "behavioroverride"="redirectAs404"
-  "x-ms-client-caller"="markReadStatus"
-  "origin"="https://teams.microsoft.com"
-  "sec-fetch-site"="same-site"
-  "sec-fetch-mode"="cors"
-  "sec-fetch-dest"="empty"
-  "referer"="https://teams.microsoft.com/"
-  "accept-encoding"="gzip, deflate, br"
-  "accept-language"="es,es-ES;q=0.9,en;q=0.8,en-GB;q=0.7,en-US;q=0.6"
-} `
--ContentType "application/json" `
--Body "{`"isread`":true}"
+			Start-Sleep -Milliseconds 500;
+
+		}
+		catch {
+
+			Start-Sleep -Milliseconds 2500;
+			Write-Warning("Code: "+$_.Exception.Response.StatusCode+" | Description: "+$_.Exception.Response.StatusDescription);
+
+			Continue;
+			
+
+		}
+
+	}
+
+	Write-Host "Next URL = "$URL;
 
 }


### PR DESCRIPTION
## Thanks

Thank you, @get-itips , for this! I stumbled across this, which proved extremely useful! I know very little PowerShell syntax, so excuse me if anything isn't as efficient as it could be!

## Bits I've added

- Saved the generated token as a global variable so that 2FA isn't required if the script is re-run
- While loop added to follow paginated pages
- Added delays to minimise API limits being hit
- Added some nicer error handling for when any API limits are hit
- Change the "pageSize" to be a passed argument
- Minor tweaks to remove repeated URLs and URIs being defined

## Execution Example

An example of executing with the "pageSize" is: "TeamsClear 300" to use a page size of 300. I have set up a scripts directory on my machine, which I have added to my system path, as it allows me to simply call the cmd name and argument as stated above.